### PR TITLE
Feat: Added cue vet output with mocked Kubevela context

### DIFF
--- a/validation/examples/dummy.cue
+++ b/validation/examples/dummy.cue
@@ -28,7 +28,7 @@ template: {
 	output: {
 
 	}
-	// parameter: {
-
-	// }
+	parameter: {
+		foo: boo
+	}
 }

--- a/validation/examples/dummy.cue
+++ b/validation/examples/dummy.cue
@@ -25,6 +25,9 @@
 	type:        "componen"
 }
 template: {
+	_metadata: {
+		foo: context.names
+	}
 	output: {
 
 	}

--- a/validation/examples/dummy.cue
+++ b/validation/examples/dummy.cue
@@ -32,6 +32,6 @@ template: {
 
 	}
 	parameter: {
-		foo: boo
+		foo: bool
 	}
 }

--- a/validation/src/CueVetDiagnosticsProvider.ts
+++ b/validation/src/CueVetDiagnosticsProvider.ts
@@ -1,0 +1,43 @@
+import * as vscode from 'vscode';
+import { DiagnosticProvider } from './DiagnosticsProvider';
+
+export class CueVetDiagnosticsProvider implements DiagnosticProvider {
+    private collection: vscode.DiagnosticCollection
+
+    constructor(collection: vscode.DiagnosticCollection) {
+        this.collection = collection;
+    }
+
+    getCollection(): vscode.DiagnosticCollection {
+        return this.collection;
+    }
+
+    resolveCommand(filepath: string): string {
+        return `cue vet ${filepath}`;
+    }
+
+    findRange(document: vscode.TextDocument, problem: string): vscode.Range {
+        // template.parameter.foo: reference "boo" not found:
+        // ./Users/kuba/personal_repos/vscode-plugin/validation/examples/dummy.cue:32:8
+        const lineAndColumn = problem.match(/(.+)\:(\d+)\:(\d+)\n?$/)?.slice(2).map(val => parseInt(val, 10) - 1);
+
+        if (lineAndColumn?.length == 2) {
+            const [line, column] = lineAndColumn;
+            return new vscode.Range(
+                new vscode.Position(line, column),
+                document.positionAt(document.offsetAt(new vscode.Position(line + 1, 0)) - 1)
+            );
+        } else {
+            return new vscode.Range(new vscode.Position(0, 0), new vscode.Position(document.lineCount, 0));
+        }
+    }
+
+    findCoreProblem(problem: string): string {
+        // template.parameter.foo: reference "boo" not found:
+        // ./Users/kuba/personal_repos/vscode-plugin/validation/examples/dummy.cue:32:8
+        // into
+        // template.parameter.foo: reference "boo" not found
+        return problem.replace(/\:\n(.+)/, '');
+        // return problem
+    }
+}

--- a/validation/src/CueVetDiagnosticsProvider.ts
+++ b/validation/src/CueVetDiagnosticsProvider.ts
@@ -41,6 +41,10 @@ export class CueVetDiagnosticsProvider implements DiagnosticProvider {
         return 'cue';
     }
 
+    isApplicable(document: vscode.TextDocument): boolean {
+        return document.languageId === 'cue';
+    }
+
     // This is a temporary measure to supress certain messages until all of the data injected by Kubevela controller can be mocked.
     // So far only context has been mocked.
     private shouldTemporarilyIgnore(problem: string): boolean {

--- a/validation/src/CueVetDiagnosticsProvider.ts
+++ b/validation/src/CueVetDiagnosticsProvider.ts
@@ -1,8 +1,7 @@
 import * as vscode from 'vscode';
 import { DiagnosticProvider } from './DiagnosticsProvider';
 import { spawn } from 'child_process';
-import { writeFileSync } from 'fs';
-import { mkdtempSync, rmdirSync } from 'node:fs';
+import { writeFileSync, rmSync, mkdtempSync } from 'fs';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
 import { randomBytes } from 'crypto';
@@ -42,7 +41,7 @@ export class CueVetDiagnosticsProvider implements DiagnosticProvider {
 
     deactivate(): void {
         if (this.tempDirectory) {
-            rmdirSync(this.tempDirectory);
+            rmSync(this.tempDirectory, { recursive: true });
         }
     }
 

--- a/validation/src/CueVetDiagnosticsProvider.ts
+++ b/validation/src/CueVetDiagnosticsProvider.ts
@@ -46,14 +46,13 @@ export class CueVetDiagnosticsProvider implements DiagnosticProvider {
     private shouldTemporarilyIgnore(problem: string): boolean {
         const regexes = [
             // some instances are incomplete; use the -c flag to show errors or suppress this message
-            /some instances are incomplete/,
-            // template.output.metadata.name: reference "parameter" not found
-            /reference "parameter" not found/
+            /some instances are incomplete/
         ];
 
         for (const regex of regexes) {
             const match = problem.match(regex);
             if (match !== null) {
+                console.debug(`excluding ${match}`)
                 return true;
             }
         }

--- a/validation/src/CueVetDiagnosticsProvider.ts
+++ b/validation/src/CueVetDiagnosticsProvider.ts
@@ -115,6 +115,5 @@ export class CueVetDiagnosticsProvider implements DiagnosticProvider {
         // into
         // template.parameter.foo: reference "boo" not found
         return problem.replace(/\:\n(.+)/, '');
-        // return problem
     }
 }

--- a/validation/src/CueVetDiagnosticsProvider.ts
+++ b/validation/src/CueVetDiagnosticsProvider.ts
@@ -27,7 +27,6 @@ export class CueVetDiagnosticsProvider implements DiagnosticProvider {
         namespace:      "dummy-namespace"
         output:         {}
     }`;
-    private mockContextLines = (this.mockContext.match(/\n/g) || '').length + 1;
 
     private tempDirectory: string | undefined;
 
@@ -76,7 +75,8 @@ export class CueVetDiagnosticsProvider implements DiagnosticProvider {
     }
 
     runCommand(document: vscode.TextDocument): Promise<string> {
-        const tempFileContent = this.mockContext.concat('\n').concat(document.getText());
+        // This aims to replicate the technique suggested in https://kubevela-docs.oss-cn-beijing.aliyuncs.com/docs/v1.0/platform-engineers/debug-test-cue#debug-cue-template
+        const tempFileContent = document.getText().concat('\n').concat(this.mockContext);
 
         const fileName = `${randomBytes(16).toString("hex")}.cue`;
 
@@ -109,7 +109,6 @@ export class CueVetDiagnosticsProvider implements DiagnosticProvider {
 
         if (lineAndColumn?.length == 2) {
             let [line, column] = lineAndColumn;
-            line = line - this.mockContextLines;
 
             return new vscode.Range(
                 new vscode.Position(line, column),

--- a/validation/src/CueVetDiagnosticsProvider.ts
+++ b/validation/src/CueVetDiagnosticsProvider.ts
@@ -17,15 +17,7 @@ export class CueVetDiagnosticsProvider implements DiagnosticProvider {
         namespace:      string
         output:         _
     }
-    
-    context: #Context & {
-        appRevision:    "v1"
-        appRevisionNum: 1
-        appName:        "dummy-app-name"
-        name:           "dummy-name"
-        namespace:      "dummy-namespace"
-        output:         {}
-    }`;
+    context: #Context`;
 
     private tempDirectory: string | undefined;
 

--- a/validation/src/CueVetDiagnosticsProvider.ts
+++ b/validation/src/CueVetDiagnosticsProvider.ts
@@ -16,6 +16,7 @@ export class CueVetDiagnosticsProvider implements DiagnosticProvider {
         name:           string
         namespace:      string
         output:         _
+        outputs:        _
     }
     context: #Context`;
 

--- a/validation/src/DiagnosticsProvider.ts
+++ b/validation/src/DiagnosticsProvider.ts
@@ -1,0 +1,11 @@
+import * as vscode from 'vscode';
+
+export interface DiagnosticProvider {
+    getCollection(): vscode.DiagnosticCollection
+
+    resolveCommand(filepath: string): string
+
+    findRange(document: vscode.TextDocument, problem: string): vscode.Range
+
+    findCoreProblem(problem: string): string
+}

--- a/validation/src/DiagnosticsProvider.ts
+++ b/validation/src/DiagnosticsProvider.ts
@@ -3,6 +3,8 @@ import * as vscode from 'vscode';
 export interface DiagnosticProvider {
     getName(): string
 
+    isApplicable(document: vscode.TextDocument): boolean
+
     getCollection(): vscode.DiagnosticCollection
 
     runCommand(document: vscode.TextDocument): Promise<string>

--- a/validation/src/DiagnosticsProvider.ts
+++ b/validation/src/DiagnosticsProvider.ts
@@ -1,11 +1,17 @@
 import * as vscode from 'vscode';
 
 export interface DiagnosticProvider {
+    getName(): string
+
     getCollection(): vscode.DiagnosticCollection
 
-    resolveCommand(filepath: string): string
+    runCommand(document: vscode.TextDocument): Promise<string>
 
     findRange(document: vscode.TextDocument, problem: string): vscode.Range
 
     findCoreProblem(problem: string): string
+
+    activate(): void
+
+    deactivate(): void
 }

--- a/validation/src/VelaVetDiagnosticsProvider.ts
+++ b/validation/src/VelaVetDiagnosticsProvider.ts
@@ -1,5 +1,6 @@
 import * as vscode from 'vscode';
 import { DiagnosticProvider } from './DiagnosticsProvider';
+import { spawn } from 'child_process';
 
 export class VelaVetDiagnosticsProvider implements DiagnosticProvider {
     private collection: vscode.DiagnosticCollection
@@ -8,12 +9,36 @@ export class VelaVetDiagnosticsProvider implements DiagnosticProvider {
         this.collection = collection;
     }
 
+    activate(): void {
+
+    }
+
+    deactivate(): void {
+
+    }
+
+    getName(): string {
+        return 'vela';
+    }
+
     getCollection(): vscode.DiagnosticCollection {
         return this.collection;
     }
 
-    resolveCommand(filepath: string): string {
-        return `vela def vet ${filepath}`;
+    runCommand(document: vscode.TextDocument): Promise<string> {
+        const command = `vela def vet ${document.fileName}`;
+
+        const process = spawn(command, { shell: true });
+
+        return new Promise((resolve, reject) => {
+            process.stdout.on('data', (data) => {
+                resolve(data.toString());
+            });
+
+            process.stderr.on('data', (data) => {
+                reject(data.toString());
+            });
+        });
     }
 
     findRange(document: vscode.TextDocument, problem: string): vscode.Range {

--- a/validation/src/VelaVetDiagnosticsProvider.ts
+++ b/validation/src/VelaVetDiagnosticsProvider.ts
@@ -21,6 +21,10 @@ export class VelaVetDiagnosticsProvider implements DiagnosticProvider {
         return 'vela';
     }
 
+    isApplicable(document: vscode.TextDocument): boolean {
+        return document.languageId === 'cue' && document.getText().includes('template:');
+    }
+
     getCollection(): vscode.DiagnosticCollection {
         return this.collection;
     }

--- a/validation/src/VelaVetDiagnosticsProvider.ts
+++ b/validation/src/VelaVetDiagnosticsProvider.ts
@@ -1,0 +1,60 @@
+import * as vscode from 'vscode';
+import { DiagnosticProvider } from './DiagnosticsProvider';
+
+export class VelaVetDiagnosticsProvider implements DiagnosticProvider {
+    private collection: vscode.DiagnosticCollection
+
+    constructor(collection: vscode.DiagnosticCollection) {
+        this.collection = collection;
+    }
+
+    getCollection(): vscode.DiagnosticCollection {
+        return this.collection;
+    }
+
+    resolveCommand(filepath: string): string {
+        return `vela def vet ${filepath}`;
+    }
+
+    findRange(document: vscode.TextDocument, problem: string): vscode.Range {
+        const regexes = [
+            // Error: failed to parse CUE: /Users/kuba/personal_repos/vscode-plugin/validation/examples/dummy.cue: invalid type trit
+            /invalid type (.+)/,
+            // Error: failed to parse CUE: /Users/kuba/personal_repos/vscode-plugin/validation/examples/dummy.cue: invalid definition spec: json: cannot unmarshal number into Go struct field TraitDefinitionSpec.podDisruptive of type bool
+            // Error: failed to parse CUE: /Users/kuba/personal_repos/vscode-plugin/validation/examples/dummy.cue: invalid definition spec: json: cannot unmarshal number into Go struct field WorkloadTypeDescriptor.workload.type of type string
+            /field [\w\.]+\.+(\w+) of type/,
+            // Error: failed to parse CUE: /Users/kuba/personal_repos/vscode-plugin/validation/examples/dummy.cue: test2.attributes.podDisruptive: reference "tru" not found
+            /reference \"(.+)\" not found/,
+            // Error: failed to parse CUE: /Users/kuba/personal_repos/vscode-plugin/validation/examples/dummy.cue: invalid definition spec: json: unknown field "podDisruptive"
+            /unknown field "(.+)"/
+        ];
+
+        let keyword: string | undefined;
+        for (const regex of regexes) {
+            const match = problem.match(regex);
+
+            if (match && match.length > 0) {
+                keyword = match.slice(-1)[0];
+                break;
+            }
+        }
+
+        if (!keyword) {
+            return new vscode.Range(new vscode.Position(0, 0), new vscode.Position(document.lineCount, 0));
+        }
+
+        const startOffset = document.getText().indexOf(keyword);
+        const endOffset = startOffset + keyword.length;
+        return new vscode.Range(
+            document.positionAt(startOffset),
+            document.positionAt(endOffset)
+        );
+    }
+
+    findCoreProblem(problem: string): string {
+        // Error: failed to parse CUE: /Users/kuba/personal_repos/vscode-plugin/validation/examples/dummy.cue: invalid definition spec: json: unknown field "podDisruptive"
+        // into
+        // invalid definition spec: json: unknown field "podDisruptive"
+        return problem.replace(/Error\: failed to parse CUE\:\s.+\.\w+\:\s/, '');
+    }
+}

--- a/validation/src/extension.ts
+++ b/validation/src/extension.ts
@@ -3,29 +3,13 @@ import * as vscode from 'vscode';
 import * as path from 'path';
 import { spawn } from 'child_process';
 
+import { DiagnosticProvider } from './DiagnosticsProvider';
+import { CueVetDiagnosticsProvider } from './CueVetDiagnosticsProvider';
+import { VelaVetDiagnosticsProvider } from './VelaVetDiagnosticsProvider';
+
 let disposables: Disposable[] = [];
 
-export function activate(context: ExtensionContext) {
-  const collection = languages.createDiagnosticCollection('vela');
-  if (window.activeTextEditor) {
-    updateDiagnostics(window.activeTextEditor.document, collection);
-  }
-
-  context.subscriptions.push(workspace.onDidChangeTextDocument(documentEvent => {
-    if (documentEvent) {
-      updateDiagnostics(documentEvent.document, collection);
-    }
-  }));
-
-  context.subscriptions.push(window.onDidChangeActiveTextEditor(editor => {
-    if (editor) {
-      updateDiagnostics(editor.document, collection);
-    }
-  }));
-}
-
-function runVelaVet(document: vscode.TextDocument): Promise<string> {
-  const command = `vela def vet ${document.fileName}`;
+function runCommand(command: string): Promise<string> {
   const process = spawn(command, { shell: true });
 
   return new Promise((resolve, reject) => {
@@ -39,71 +23,60 @@ function runVelaVet(document: vscode.TextDocument): Promise<string> {
   });
 }
 
-function determineKeyword(problem: string): string | undefined {
-  const regexes = [
-    // Error: failed to parse CUE: /Users/kuba/personal_repos/vscode-plugin/validation/examples/dummy.cue: invalid type trit
-    /invalid type (.+)/,
-    // Error: failed to parse CUE: /Users/kuba/personal_repos/vscode-plugin/validation/examples/dummy.cue: invalid definition spec: json: cannot unmarshal number into Go struct field TraitDefinitionSpec.podDisruptive of type bool
-    // Error: failed to parse CUE: /Users/kuba/personal_repos/vscode-plugin/validation/examples/dummy.cue: invalid definition spec: json: cannot unmarshal number into Go struct field WorkloadTypeDescriptor.workload.type of type string
-    /field [\w\.]+\.+(\w+) of type/,
-    // Error: failed to parse CUE: /Users/kuba/personal_repos/vscode-plugin/validation/examples/dummy.cue: test2.attributes.podDisruptive: reference "tru" not found
-    /reference \"(.+)\" not found/,
-    // Error: failed to parse CUE: /Users/kuba/personal_repos/vscode-plugin/validation/examples/dummy.cue: invalid definition spec: json: unknown field "podDisruptive"
-    /unknown field "(.+)"/
-  ];
-
-  for (const regex of regexes) {
-    const match = problem.match(regex);
-
-    if (match && match.length > 0) {
-      return match.slice(-1)[0];
-    }
-  }
-}
-
-function findRange(document: vscode.TextDocument, keyword: string | undefined): vscode.Range {
-  if (!keyword) {
-    return new vscode.Range(new vscode.Position(0, 0), new vscode.Position(document.lineCount, 0));
-  }
-
-  const startOffset = document.getText().indexOf(keyword);
-  const endOffset = startOffset + keyword.length;
-  return new vscode.Range(
-    document.positionAt(startOffset),
-    document.positionAt(endOffset)
-  );
-}
-
-function updateDiagnostics(document: vscode.TextDocument, collection: vscode.DiagnosticCollection): void {
-
+async function updateDiagnostics(document: vscode.TextDocument, diagnosticProvider: DiagnosticProvider): Promise<void> {
   if (document && path.basename(document.uri.fsPath).endsWith('.cue')) {
-
-    const velaPromise = runVelaVet(document);
-
-    velaPromise.then((_good) => {
-      collection.clear();
-    }).catch((problem) => {
-
+    try {
+      await runCommand(diagnosticProvider.resolveCommand(document.fileName));
+      diagnosticProvider.getCollection().clear();
+    } catch (problem) {
       console.debug(problem);
 
-      const keyword = determineKeyword(problem);
-      console.debug(keyword);
+      const coreProblem = diagnosticProvider.findCoreProblem(problem as string);
+      const range = diagnosticProvider.findRange(document, problem as string);
 
-      const range = findRange(document, keyword);
-
-      collection.set(document.uri, [{
-        message: problem,
+      diagnosticProvider.getCollection().set(document.uri, [{
+        message: coreProblem,
         range,
         severity: vscode.DiagnosticSeverity.Error,
         source: '',
         relatedInformation: [
-          new vscode.DiagnosticRelatedInformation(new vscode.Location(document.uri, range), problem.split(':').slice(-1)[0])
+          new vscode.DiagnosticRelatedInformation(new vscode.Location(document.uri, range), coreProblem)
         ]
       }]);
-    });
+    }
   } else {
-    collection.clear();
+    diagnosticProvider.getCollection().clear();
   }
+}
+
+export function activate(context: ExtensionContext) {
+  const diagnosticProviders: DiagnosticProvider[] = [
+    new VelaVetDiagnosticsProvider(languages.createDiagnosticCollection('vela vet')),
+    new CueVetDiagnosticsProvider(languages.createDiagnosticCollection('cue vet'))
+  ];
+
+
+  if (window.activeTextEditor) {
+    for (const provider of diagnosticProviders) {
+      updateDiagnostics(window.activeTextEditor.document, provider);
+    }
+  }
+
+  context.subscriptions.push(workspace.onDidChangeTextDocument(documentEvent => {
+    if (documentEvent) {
+      for (const provider of diagnosticProviders) {
+        updateDiagnostics(documentEvent.document, provider);
+      }
+    }
+  }));
+
+  context.subscriptions.push(window.onDidChangeActiveTextEditor(editor => {
+    if (editor) {
+      for (const provider of diagnosticProviders) {
+        updateDiagnostics(editor.document, provider);
+      }
+    }
+  }));
 }
 
 // this method is called when your extension is deactivated

--- a/validation/src/extension.ts
+++ b/validation/src/extension.ts
@@ -1,6 +1,5 @@
 import { ExtensionContext, languages, Disposable, workspace, window } from 'vscode';
 import * as vscode from 'vscode';
-import * as path from 'path';
 
 import { DiagnosticProvider } from './DiagnosticsProvider';
 import { CueVetDiagnosticsProvider } from './CueVetDiagnosticsProvider';
@@ -10,7 +9,7 @@ let disposables: Disposable[] = [];
 
 
 async function updateDiagnostics(document: vscode.TextDocument, diagnosticProvider: DiagnosticProvider): Promise<void> {
-  if (document && path.basename(document.uri.fsPath).endsWith('.cue')) {
+  if (diagnosticProvider.isApplicable(document)) {
     try {
       await diagnosticProvider.runCommand(document);
       diagnosticProvider.getCollection().clear();


### PR DESCRIPTION
This PR replicates this technique: https://kubevela-docs.oss-cn-beijing.aliyuncs.com/docs/v1.0/platform-engineers/debug-test-cue#debug-cue-template, but in an extension form.

![CleanShot 2024-04-19 at 15 30 24@2x](https://github.com/kubevela-contrib/vscode-plugin/assets/503380/c257160e-3710-4210-99f8-3e9a9754b1e6)
![CleanShot 2024-04-19 at 15 30 40@2x](https://github.com/kubevela-contrib/vscode-plugin/assets/503380/22ff6087-27d7-4508-8744-31d54c8cead3)

It's also a bit of a refactor, so we can run multiple diagnostics types (`vela def vet`, and `cue vet` so far) within the same extension without crazy code duplication.
