### PR TITLE
feat: dynamic YAML schema provider for Vela applications

### DIFF
--- a/validation/package.json
+++ b/validation/package.json
@@ -12,9 +12,6 @@
   "categories": [
     "Other"
   ],
-  "extensionDependencies": [
-    "redhat.vscode-yaml"
-  ],
   "activationEvents": [
     "*"
   ],

--- a/validation/package.json
+++ b/validation/package.json
@@ -12,6 +12,9 @@
   "categories": [
     "Other"
   ],
+  "extensionDependencies": [
+    "redhat.vscode-yaml"
+  ],
   "activationEvents": [
     "*"
   ],

--- a/validation/package.json
+++ b/validation/package.json
@@ -13,7 +13,8 @@
     "Other"
   ],
   "activationEvents": [
-    "*"
+    "onLanguage:yaml",
+    "onLanguage:manifest-yaml"
   ],
   "main": "./out/extension",
   "contributes": {

--- a/validation/src/VelaYamlSchemaProvider.ts
+++ b/validation/src/VelaYamlSchemaProvider.ts
@@ -75,6 +75,10 @@ function parseApplicationSchema(crdJson: string): JsonObject {
     if (!openAPISchema) {
         throw new Error('No openAPIV3Schema found in CRD');
     }
+    const props = (openAPISchema as any).properties;
+    if (props) {
+        delete props.status;
+    }
     return openAPISchema;
 }
 

--- a/validation/src/VelaYamlSchemaProvider.ts
+++ b/validation/src/VelaYamlSchemaProvider.ts
@@ -34,24 +34,31 @@ interface YamlExtensionApi {
 }
 
 function isVelaApplication(content: string): boolean {
-    const lines = content.split('\n').slice(0, 10);
     let hasApiVersion = false;
     let hasKind = false;
+    let contentLines = 0;
 
-    for (const line of lines) {
+    for (const line of content.split('\n')) {
         const trimmed = line.trim();
-        if (trimmed.startsWith('#')) {
+        if (trimmed === '' || trimmed.startsWith('#')) {
             continue;
         }
+        contentLines++;
         if (trimmed === `apiVersion: ${OAM_API_VERSION}`) {
             hasApiVersion = true;
         }
         if (trimmed === `kind: ${OAM_KIND}`) {
             hasKind = true;
         }
+        if (hasApiVersion && hasKind) {
+            return true;
+        }
+        if (contentLines >= 10) {
+            break;
+        }
     }
 
-    return hasApiVersion && hasKind;
+    return false;
 }
 
 const KUBECTL_OPTS = { timeout: 10_000, maxBuffer: 10 * 1024 * 1024 };

--- a/validation/src/VelaYamlSchemaProvider.ts
+++ b/validation/src/VelaYamlSchemaProvider.ts
@@ -73,37 +73,35 @@ const METADATA_RUNTIME_FIELDS = [
     'resourceVersion', 'selfLink', 'uid',
 ];
 
-function parseObjectMeta(openApiJson: string): JsonObject {
-    const spec = JSON.parse(openApiJson);
-    const key = 'io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta';
-    const meta = spec.components?.schemas?.[key] ?? spec.definitions?.[key];
-    if (!meta) {
-        throw new Error('ObjectMeta not found in OpenAPI spec');
-    }
-    const props = meta.properties;
-    if (props) {
-        for (const field of METADATA_RUNTIME_FIELDS) {
-            delete props[field];
-        }
-    }
-    delete meta.required;
-    return meta;
-}
+function parseApplicationSchema(oamOpenApiJson: string): JsonObject {
+    const spec = JSON.parse(oamOpenApiJson);
+    const schemas = spec.components?.schemas ?? {};
 
-function parseApplicationSchema(crdJson: string, objectMeta: JsonObject): JsonObject {
-    const crd = JSON.parse(crdJson);
-    const versions = crd.spec.versions as Array<{ name: string; schema?: { openAPIV3Schema?: JsonObject } }>;
-    const latest = versions[versions.length - 1];
-    const openAPISchema = latest?.schema?.openAPIV3Schema;
-    if (!openAPISchema) {
-        throw new Error('No openAPIV3Schema found in CRD');
+    const app = schemas['dev.oam.core.v1beta1.Application'];
+    if (!app) {
+        throw new Error('Application schema not found in OAM OpenAPI spec');
     }
-    const props = (openAPISchema as any).properties;
+
+    const meta = schemas['io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta'];
+    if (meta) {
+        const metaProps = meta.properties;
+        if (metaProps) {
+            for (const field of METADATA_RUNTIME_FIELDS) {
+                delete metaProps[field];
+            }
+        }
+        delete meta.required;
+    }
+
+    const props = app.properties;
     if (props) {
         delete props.status;
-        props.metadata = objectMeta;
+        if (meta) {
+            props.metadata = meta;
+        }
     }
-    return openAPISchema;
+
+    return app;
 }
 
 function filterConfigMapNames(nameListOutput: string, prefix: string): string[] {
@@ -113,16 +111,33 @@ function filterConfigMapNames(nameListOutput: string, prefix: string): string[] 
         .filter(n => !/-v\d+$/.test(n));
 }
 
-function parseDefinitionDescriptions(definitionsJson: string): Map<string, string> {
-    const descriptions = new Map<string, string>();
-    const items = JSON.parse(definitionsJson).items as Array<{ metadata: { name: string; annotations?: Record<string, string> } }>;
+interface DescriptionsByKind {
+    components: Map<string, string>;
+    traits: Map<string, string>;
+    policies: Map<string, string>;
+}
+
+const DEFINITION_KIND_TO_KEY: Record<string, keyof DescriptionsByKind> = {
+    ComponentDefinition: 'components',
+    TraitDefinition: 'traits',
+    PolicyDefinition: 'policies',
+};
+
+function parseDefinitionDescriptions(definitionsJson: string): DescriptionsByKind {
+    const result: DescriptionsByKind = {
+        components: new Map(),
+        traits: new Map(),
+        policies: new Map(),
+    };
+    const items = JSON.parse(definitionsJson).items as Array<{ kind: string; metadata: { name: string; annotations?: Record<string, string> } }>;
     for (const item of items) {
+        const key = DEFINITION_KIND_TO_KEY[item.kind];
         const desc = item.metadata.annotations?.['definition.oam.dev/description'];
-        if (desc) {
-            descriptions.set(item.metadata.name, desc);
+        if (key && desc) {
+            result[key].set(item.metadata.name, desc);
         }
     }
-    return descriptions;
+    return result;
 }
 
 function parseConfigMapSchema(name: string, prefix: string, cmJson: string): [string, JsonObject] | undefined {
@@ -299,16 +314,13 @@ export class VelaYamlSchemaProvider {
     }
 
     private fetchSchemaFromClusterSync(): void {
-        const objectMeta = parseObjectMeta(kubectlSync('get --raw /openapi/v3/api/v1'));
-        const appSchema = parseApplicationSchema(kubectlSync('get crd applications.core.oam.dev -o json'), objectMeta);
+        const appSchema = parseApplicationSchema(kubectlSync('get --raw /openapi/v3/apis/core.oam.dev/v1beta1'));
         const cmNameList = kubectlSync('get configmaps -n vela-system -o name');
-        const componentDescs = parseDefinitionDescriptions(kubectlSync('get componentdefinitions.core.oam.dev -n vela-system -o json'));
-        const traitDescs = parseDefinitionDescriptions(kubectlSync('get traitdefinitions.core.oam.dev -n vela-system -o json'));
-        const policyDescs = parseDefinitionDescriptions(kubectlSync('get policydefinitions.core.oam.dev -n vela-system -o json'));
+        const descs = parseDefinitionDescriptions(kubectlSync('get componentdefinitions.core.oam.dev,traitdefinitions.core.oam.dev,policydefinitions.core.oam.dev -n vela-system -o json'));
         const schemas: SchemasByKind = {
-            components: { schemas: this.fetchConfigMapSchemasSync(cmNameList, 'component-schema-'), descriptions: componentDescs },
-            traits: { schemas: this.fetchConfigMapSchemasSync(cmNameList, 'trait-schema-'), descriptions: traitDescs },
-            policies: { schemas: this.fetchConfigMapSchemasSync(cmNameList, 'policy-schema-'), descriptions: policyDescs },
+            components: { schemas: this.fetchConfigMapSchemasSync(cmNameList, 'component-schema-'), descriptions: descs.components },
+            traits: { schemas: this.fetchConfigMapSchemasSync(cmNameList, 'trait-schema-'), descriptions: descs.traits },
+            policies: { schemas: this.fetchConfigMapSchemasSync(cmNameList, 'policy-schema-'), descriptions: descs.policies },
         };
         const composed = makeDefaultedFieldsOptional(composeSchema(appSchema, schemas)) as JsonObject;
         composed.title = `KubeVela Application | Cluster: ${getK8sContext()}`;
@@ -324,16 +336,13 @@ export class VelaYamlSchemaProvider {
 
         (async () => {
             try {
-                const objectMeta = parseObjectMeta(await kubectlAsync('get --raw /openapi/v3/api/v1'));
-                const appSchema = parseApplicationSchema(await kubectlAsync('get crd applications.core.oam.dev -o json'), objectMeta);
+                const appSchema = parseApplicationSchema(await kubectlAsync('get --raw /openapi/v3/apis/core.oam.dev/v1beta1'));
                 const cmNameList = await kubectlAsync('get configmaps -n vela-system -o name');
-                const componentDescs = parseDefinitionDescriptions(await kubectlAsync('get componentdefinitions.core.oam.dev -n vela-system -o json'));
-                const traitDescs = parseDefinitionDescriptions(await kubectlAsync('get traitdefinitions.core.oam.dev -n vela-system -o json'));
-                const policyDescs = parseDefinitionDescriptions(await kubectlAsync('get policydefinitions.core.oam.dev -n vela-system -o json'));
+                const descs = parseDefinitionDescriptions(await kubectlAsync('get componentdefinitions.core.oam.dev,traitdefinitions.core.oam.dev,policydefinitions.core.oam.dev -n vela-system -o json'));
                 const schemas: SchemasByKind = {
-                    components: { schemas: await this.fetchConfigMapSchemasAsync(cmNameList, 'component-schema-'), descriptions: componentDescs },
-                    traits: { schemas: await this.fetchConfigMapSchemasAsync(cmNameList, 'trait-schema-'), descriptions: traitDescs },
-                    policies: { schemas: await this.fetchConfigMapSchemasAsync(cmNameList, 'policy-schema-'), descriptions: policyDescs },
+                    components: { schemas: await this.fetchConfigMapSchemasAsync(cmNameList, 'component-schema-'), descriptions: descs.components },
+                    traits: { schemas: await this.fetchConfigMapSchemasAsync(cmNameList, 'trait-schema-'), descriptions: descs.traits },
+                    policies: { schemas: await this.fetchConfigMapSchemasAsync(cmNameList, 'policy-schema-'), descriptions: descs.policies },
                 };
                 const composed = makeDefaultedFieldsOptional(composeSchema(appSchema, schemas)) as JsonObject;
                 composed.title = `KubeVela Application | Cluster: ${getK8sContext()}`;

--- a/validation/src/VelaYamlSchemaProvider.ts
+++ b/validation/src/VelaYamlSchemaProvider.ts
@@ -82,21 +82,21 @@ function parseApplicationSchema(crdJson: string): JsonObject {
     return openAPISchema;
 }
 
-function filterComponentConfigMapNames(nameListOutput: string): string[] {
+function filterConfigMapNames(nameListOutput: string, prefix: string): string[] {
     return nameListOutput.trim().split('\n')
         .map(n => n.replace('configmap/', ''))
-        .filter(n => n.startsWith('component-schema-'))
+        .filter(n => n.startsWith(prefix))
         .filter(n => !/-v\d+$/.test(n));
 }
 
-function parseComponentSchema(name: string, cmJson: string): [string, JsonObject] | undefined {
+function parseConfigMapSchema(name: string, prefix: string, cmJson: string): [string, JsonObject] | undefined {
     const cm = JSON.parse(cmJson);
-    const componentType = name.replace('component-schema-', '');
+    const type = name.replace(prefix, '');
     const data: Record<string, string> = cm.data ?? {};
     const schemaKey = Object.keys(data).find(k => k.endsWith('.json') || k === 'openapi-v3-json-schema');
     const schemaStr = schemaKey ? data[schemaKey] : Object.values(data)[0];
     if (schemaStr) {
-        return [componentType, JSON.parse(schemaStr)];
+        return [type, JSON.parse(schemaStr)];
     }
     return undefined;
 }
@@ -128,18 +128,21 @@ function makeDefaultedFieldsOptional(schema: unknown): unknown {
     return schema;
 }
 
-function composeSchema(appSchema: JsonObject, componentSchemas: Map<string, JsonObject>): JsonObject {
-    const spec = (appSchema as any).properties?.spec;
-    const components = spec?.properties?.components;
-    if (!components?.items) {
-        return appSchema;
-    }
+interface SchemasByKind {
+    components: Map<string, JsonObject>;
+    traits: Map<string, JsonObject>;
+    policies: Map<string, JsonObject>;
+}
 
+function injectAllOf(itemsNode: JsonObject | undefined, schemas: Map<string, JsonObject>): void {
+    if (!itemsNode || schemas.size === 0) {
+        return;
+    }
     const allOf: JsonObject[] = [];
-    for (const [componentType, schema] of componentSchemas) {
+    for (const [type, schema] of schemas) {
         allOf.push({
             if: {
-                properties: { type: { const: componentType } },
+                properties: { type: { const: type } },
                 required: ['type'],
             },
             then: {
@@ -147,11 +150,22 @@ function composeSchema(appSchema: JsonObject, componentSchemas: Map<string, Json
             },
         });
     }
+    itemsNode.allOf = allOf;
+}
 
-    components.items = {
-        ...components.items,
-        allOf,
-    };
+function composeSchema(appSchema: JsonObject, schemas: SchemasByKind): JsonObject {
+    const spec = (appSchema as any).properties?.spec;
+    const componentItems = spec?.properties?.components?.items;
+
+    injectAllOf(componentItems, schemas.components);
+    injectAllOf(componentItems?.properties?.traits?.items, schemas.traits);
+    injectAllOf(spec?.properties?.policies?.items, schemas.policies);
+
+    console.log('composeSchema: components allOf count:', schemas.components.size);
+    console.log('composeSchema: traits allOf count:', schemas.traits.size);
+    console.log('composeSchema: policies allOf count:', schemas.policies.size);
+    console.log('composeSchema: traits items node exists:', !!componentItems?.properties?.traits?.items);
+    console.log('composeSchema: policies items node exists:', !!spec?.properties?.policies?.items);
 
     return appSchema;
 }
@@ -209,17 +223,37 @@ export class VelaYamlSchemaProvider {
         }
     }
 
-    private fetchSchemaFromClusterSync(): void {
-        const appSchema = parseApplicationSchema(kubectlSync('get crd applications.core.oam.dev -o json'));
-        const cmNames = filterComponentConfigMapNames(kubectlSync('get configmaps -n vela-system -o name'));
-        const componentSchemas = new Map<string, JsonObject>();
-        for (const name of cmNames) {
-            const entry = parseComponentSchema(name, kubectlSync(`get configmap ${name} -n vela-system -o json`));
+    private fetchConfigMapSchemasSync(nameListOutput: string, prefix: string): Map<string, JsonObject> {
+        const schemas = new Map<string, JsonObject>();
+        for (const name of filterConfigMapNames(nameListOutput, prefix)) {
+            const entry = parseConfigMapSchema(name, prefix, kubectlSync(`get configmap ${name} -n vela-system -o json`));
             if (entry) {
-                componentSchemas.set(...entry);
+                schemas.set(...entry);
             }
         }
-        const composed = makeDefaultedFieldsOptional(composeSchema(appSchema, componentSchemas)) as JsonObject;
+        return schemas;
+    }
+
+    private async fetchConfigMapSchemasAsync(nameListOutput: string, prefix: string): Promise<Map<string, JsonObject>> {
+        const schemas = new Map<string, JsonObject>();
+        for (const name of filterConfigMapNames(nameListOutput, prefix)) {
+            const entry = parseConfigMapSchema(name, prefix, await kubectlAsync(`get configmap ${name} -n vela-system -o json`));
+            if (entry) {
+                schemas.set(...entry);
+            }
+        }
+        return schemas;
+    }
+
+    private fetchSchemaFromClusterSync(): void {
+        const appSchema = parseApplicationSchema(kubectlSync('get crd applications.core.oam.dev -o json'));
+        const cmNameList = kubectlSync('get configmaps -n vela-system -o name');
+        const schemas: SchemasByKind = {
+            components: this.fetchConfigMapSchemasSync(cmNameList, 'component-schema-'),
+            traits: this.fetchConfigMapSchemasSync(cmNameList, 'trait-schema-'),
+            policies: this.fetchConfigMapSchemasSync(cmNameList, 'policy-schema-'),
+        };
+        const composed = makeDefaultedFieldsOptional(composeSchema(appSchema, schemas)) as JsonObject;
         composed.title = `KubeVela Application | Cluster: ${getK8sContext()}`;
         this.schemaContent = JSON.stringify(composed);
         this.writeCache(this.schemaContent);
@@ -234,15 +268,13 @@ export class VelaYamlSchemaProvider {
         (async () => {
             try {
                 const appSchema = parseApplicationSchema(await kubectlAsync('get crd applications.core.oam.dev -o json'));
-                const cmNames = filterComponentConfigMapNames(await kubectlAsync('get configmaps -n vela-system -o name'));
-                const componentSchemas = new Map<string, JsonObject>();
-                for (const name of cmNames) {
-                    const entry = parseComponentSchema(name, await kubectlAsync(`get configmap ${name} -n vela-system -o json`));
-                    if (entry) {
-                        componentSchemas.set(...entry);
-                    }
-                }
-                const composed = makeDefaultedFieldsOptional(composeSchema(appSchema, componentSchemas)) as JsonObject;
+                const cmNameList = await kubectlAsync('get configmaps -n vela-system -o name');
+                const schemas: SchemasByKind = {
+                    components: await this.fetchConfigMapSchemasAsync(cmNameList, 'component-schema-'),
+                    traits: await this.fetchConfigMapSchemasAsync(cmNameList, 'trait-schema-'),
+                    policies: await this.fetchConfigMapSchemasAsync(cmNameList, 'policy-schema-'),
+                };
+                const composed = makeDefaultedFieldsOptional(composeSchema(appSchema, schemas)) as JsonObject;
                 composed.title = `KubeVela Application | Cluster: ${getK8sContext()}`;
                 this.schemaContent = JSON.stringify(composed);
                 this.writeCache(this.schemaContent);

--- a/validation/src/VelaYamlSchemaProvider.ts
+++ b/validation/src/VelaYamlSchemaProvider.ts
@@ -17,8 +17,8 @@ function getK8sContext(): string {
     }
 }
 
-function buildSchemaUri(context: string): string {
-    return `${SCHEMA_ID}://schema/KubeVela Application | Cluster ${context}`;
+function buildSchemaUri(context: string, version: number): string {
+    return `${SCHEMA_ID}://schema/${version}/KubeVela Application | Cluster ${context}`;
 }
 
 const OAM_API_VERSION = 'core.oam.dev/v1beta1';
@@ -67,7 +67,30 @@ async function kubectlAsync(args: string): Promise<string> {
 
 type JsonObject = Record<string, unknown>;
 
-function parseApplicationSchema(crdJson: string): JsonObject {
+const METADATA_RUNTIME_FIELDS = [
+    'creationTimestamp', 'deletionGracePeriodSeconds', 'deletionTimestamp',
+    'finalizers', 'generation', 'managedFields', 'ownerReferences',
+    'resourceVersion', 'selfLink', 'uid',
+];
+
+function parseObjectMeta(openApiJson: string): JsonObject {
+    const spec = JSON.parse(openApiJson);
+    const key = 'io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta';
+    const meta = spec.components?.schemas?.[key] ?? spec.definitions?.[key];
+    if (!meta) {
+        throw new Error('ObjectMeta not found in OpenAPI spec');
+    }
+    const props = meta.properties;
+    if (props) {
+        for (const field of METADATA_RUNTIME_FIELDS) {
+            delete props[field];
+        }
+    }
+    delete meta.required;
+    return meta;
+}
+
+function parseApplicationSchema(crdJson: string, objectMeta: JsonObject): JsonObject {
     const crd = JSON.parse(crdJson);
     const versions = crd.spec.versions as Array<{ name: string; schema?: { openAPIV3Schema?: JsonObject } }>;
     const latest = versions[versions.length - 1];
@@ -78,6 +101,7 @@ function parseApplicationSchema(crdJson: string): JsonObject {
     const props = (openAPISchema as any).properties;
     if (props) {
         delete props.status;
+        props.metadata = objectMeta;
     }
     return openAPISchema;
 }
@@ -200,6 +224,7 @@ function composeSchema(appSchema: JsonObject, schemas: SchemasByKind): JsonObjec
 
 export class VelaYamlSchemaProvider {
     private schemaContent: string | undefined;
+    private schemaVersion = 0;
     private refreshing = false;
     private cachePath: string;
 
@@ -274,7 +299,8 @@ export class VelaYamlSchemaProvider {
     }
 
     private fetchSchemaFromClusterSync(): void {
-        const appSchema = parseApplicationSchema(kubectlSync('get crd applications.core.oam.dev -o json'));
+        const objectMeta = parseObjectMeta(kubectlSync('get --raw /openapi/v3/api/v1'));
+        const appSchema = parseApplicationSchema(kubectlSync('get crd applications.core.oam.dev -o json'), objectMeta);
         const cmNameList = kubectlSync('get configmaps -n vela-system -o name');
         const componentDescs = parseDefinitionDescriptions(kubectlSync('get componentdefinitions.core.oam.dev -n vela-system -o json'));
         const traitDescs = parseDefinitionDescriptions(kubectlSync('get traitdefinitions.core.oam.dev -n vela-system -o json'));
@@ -298,7 +324,8 @@ export class VelaYamlSchemaProvider {
 
         (async () => {
             try {
-                const appSchema = parseApplicationSchema(await kubectlAsync('get crd applications.core.oam.dev -o json'));
+                const objectMeta = parseObjectMeta(await kubectlAsync('get --raw /openapi/v3/api/v1'));
+                const appSchema = parseApplicationSchema(await kubectlAsync('get crd applications.core.oam.dev -o json'), objectMeta);
                 const cmNameList = await kubectlAsync('get configmaps -n vela-system -o name');
                 const componentDescs = parseDefinitionDescriptions(await kubectlAsync('get componentdefinitions.core.oam.dev -n vela-system -o json'));
                 const traitDescs = parseDefinitionDescriptions(await kubectlAsync('get traitdefinitions.core.oam.dev -n vela-system -o json'));
@@ -311,6 +338,7 @@ export class VelaYamlSchemaProvider {
                 const composed = makeDefaultedFieldsOptional(composeSchema(appSchema, schemas)) as JsonObject;
                 composed.title = `KubeVela Application | Cluster: ${getK8sContext()}`;
                 this.schemaContent = JSON.stringify(composed);
+                this.schemaVersion++;
                 this.writeCache(this.schemaContent);
             } catch (err) {
                 console.error('Failed to refresh schemas from cluster:', err);
@@ -332,7 +360,7 @@ export class VelaYamlSchemaProvider {
             : fs.readFileSync(uri.fsPath, 'utf-8');
 
         if (isVelaApplication(content)) {
-            return buildSchemaUri(getK8sContext());
+            return buildSchemaUri(getK8sContext(), this.schemaVersion);
         }
 
         return undefined;

--- a/validation/src/VelaYamlSchemaProvider.ts
+++ b/validation/src/VelaYamlSchemaProvider.ts
@@ -1,0 +1,289 @@
+import * as vscode from 'vscode';
+import * as path from 'path';
+import * as fs from 'fs';
+import { exec, execSync } from 'child_process';
+import { promisify } from 'util';
+
+const execAsync = promisify(exec);
+
+const SCHEMA_ID = 'vela-application';
+const CACHE_FILENAME = 'vela-application-schema.json';
+
+function getK8sContext(): string {
+    try {
+        return execSync('kubectl config current-context', { encoding: 'utf-8', timeout: 5_000 }).trim();
+    } catch {
+        return 'unknown';
+    }
+}
+
+function buildSchemaUri(context: string): string {
+    return `${SCHEMA_ID}://schema/KubeVela Application | Cluster ${context}`;
+}
+
+const OAM_API_VERSION = 'core.oam.dev/v1beta1';
+const OAM_KIND = 'Application';
+
+interface YamlExtensionApi {
+    registerContributor(
+        schema: string,
+        requestSchema: (resource: string) => string | undefined,
+        requestSchemaContent: (uri: string) => string | undefined,
+        label?: string
+    ): boolean;
+}
+
+function isVelaApplication(content: string): boolean {
+    const lines = content.split('\n').slice(0, 10);
+    let hasApiVersion = false;
+    let hasKind = false;
+
+    for (const line of lines) {
+        const trimmed = line.trim();
+        if (trimmed.startsWith('#')) {
+            continue;
+        }
+        if (trimmed === `apiVersion: ${OAM_API_VERSION}`) {
+            hasApiVersion = true;
+        }
+        if (trimmed === `kind: ${OAM_KIND}`) {
+            hasKind = true;
+        }
+    }
+
+    return hasApiVersion && hasKind;
+}
+
+const KUBECTL_OPTS = { timeout: 10_000, maxBuffer: 10 * 1024 * 1024 };
+
+function kubectlSync(args: string): string {
+    return execSync(`kubectl ${args}`, { encoding: 'utf-8', ...KUBECTL_OPTS });
+}
+
+async function kubectlAsync(args: string): Promise<string> {
+    const { stdout } = await execAsync(`kubectl ${args}`, KUBECTL_OPTS);
+    return stdout;
+}
+
+type JsonObject = Record<string, unknown>;
+
+function parseApplicationSchema(crdJson: string): JsonObject {
+    const crd = JSON.parse(crdJson);
+    const versions = crd.spec.versions as Array<{ name: string; schema?: { openAPIV3Schema?: JsonObject } }>;
+    const latest = versions[versions.length - 1];
+    const openAPISchema = latest?.schema?.openAPIV3Schema;
+    if (!openAPISchema) {
+        throw new Error('No openAPIV3Schema found in CRD');
+    }
+    return openAPISchema;
+}
+
+function filterComponentConfigMapNames(nameListOutput: string): string[] {
+    return nameListOutput.trim().split('\n')
+        .map(n => n.replace('configmap/', ''))
+        .filter(n => n.startsWith('component-schema-'))
+        .filter(n => !/-v\d+$/.test(n));
+}
+
+function parseComponentSchema(name: string, cmJson: string): [string, JsonObject] | undefined {
+    const cm = JSON.parse(cmJson);
+    const componentType = name.replace('component-schema-', '');
+    const data: Record<string, string> = cm.data ?? {};
+    const schemaKey = Object.keys(data).find(k => k.endsWith('.json') || k === 'openapi-v3-json-schema');
+    const schemaStr = schemaKey ? data[schemaKey] : Object.values(data)[0];
+    if (schemaStr) {
+        return [componentType, JSON.parse(schemaStr)];
+    }
+    return undefined;
+}
+
+function stripDefaultsFromRequired(schema: unknown): unknown {
+    if (Array.isArray(schema)) {
+        return schema.map(item => stripDefaultsFromRequired(item));
+    }
+    if (schema !== null && typeof schema === 'object') {
+        const obj = schema as JsonObject;
+        const result: JsonObject = {};
+        for (const [key, value] of Object.entries(obj)) {
+            result[key] = stripDefaultsFromRequired(value);
+        }
+        const required = result['required'];
+        const properties = result['properties'];
+        if (Array.isArray(required) && properties && typeof properties === 'object') {
+            const props = properties as JsonObject;
+            result['required'] = required.filter(field => {
+                const prop = props[field as string];
+                return !(prop && typeof prop === 'object' && 'default' in (prop as JsonObject));
+            });
+            if ((result['required'] as unknown[]).length === 0) {
+                delete result['required'];
+            }
+        }
+        return result;
+    }
+    return schema;
+}
+
+function composeSchema(appSchema: JsonObject, componentSchemas: Map<string, JsonObject>): JsonObject {
+    const spec = (appSchema as any).properties?.spec;
+    const components = spec?.properties?.components;
+    if (!components?.items) {
+        return appSchema;
+    }
+
+    const allOf: JsonObject[] = [];
+    for (const [componentType, schema] of componentSchemas) {
+        allOf.push({
+            if: {
+                properties: { type: { const: componentType } },
+                required: ['type'],
+            },
+            then: {
+                properties: { properties: schema },
+            },
+        });
+    }
+
+    components.items = {
+        ...components.items,
+        allOf,
+    };
+
+    return appSchema;
+}
+
+export class VelaYamlSchemaProvider {
+    private schemaContent: string | undefined;
+    private refreshing = false;
+    private cachePath: string;
+
+    constructor(private storagePath: string) {
+        this.cachePath = path.join(storagePath, CACHE_FILENAME);
+        this.loadCache();
+    }
+
+    async register(): Promise<void> {
+        const yamlExtension = vscode.extensions.getExtension<YamlExtensionApi>('redhat.vscode-yaml');
+        if (!yamlExtension) {
+            console.warn('YAML extension not found. Schema support disabled.');
+            return;
+        }
+
+        const api = yamlExtension.isActive
+            ? yamlExtension.exports
+            : await yamlExtension.activate();
+
+        if (!api || !api.registerContributor) {
+            console.warn('YAML extension API not available.');
+            return;
+        }
+
+        api.registerContributor(
+            SCHEMA_ID,
+            (resource) => this.requestSchema(resource),
+            (uri) => this.requestSchemaContent(uri),
+            'Vela Application'
+        );
+    }
+
+    private loadCache(): void {
+        try {
+            if (fs.existsSync(this.cachePath)) {
+                this.schemaContent = fs.readFileSync(this.cachePath, 'utf-8');
+            }
+        } catch (err) {
+            console.warn('Failed to load schema cache:', err);
+        }
+    }
+
+    private writeCache(content: string): void {
+        try {
+            fs.mkdirSync(this.storagePath, { recursive: true });
+            fs.writeFileSync(this.cachePath, content, 'utf-8');
+        } catch (err) {
+            console.warn('Failed to write schema cache:', err);
+        }
+    }
+
+    private fetchSchemaFromClusterSync(): void {
+        const appSchema = parseApplicationSchema(kubectlSync('get crd applications.core.oam.dev -o json'));
+        const cmNames = filterComponentConfigMapNames(kubectlSync('get configmaps -n vela-system -o name'));
+        const componentSchemas = new Map<string, JsonObject>();
+        for (const name of cmNames) {
+            const entry = parseComponentSchema(name, kubectlSync(`get configmap ${name} -n vela-system -o json`));
+            if (entry) {
+                componentSchemas.set(...entry);
+            }
+        }
+        const composed = stripDefaultsFromRequired(composeSchema(appSchema, componentSchemas)) as JsonObject;
+        composed.title = `KubeVela Application | Cluster: ${getK8sContext()}`;
+        this.schemaContent = JSON.stringify(composed);
+        this.writeCache(this.schemaContent);
+    }
+
+    private refreshInBackground(): void {
+        if (this.refreshing) {
+            return;
+        }
+        this.refreshing = true;
+
+        (async () => {
+            try {
+                const appSchema = parseApplicationSchema(await kubectlAsync('get crd applications.core.oam.dev -o json'));
+                const cmNames = filterComponentConfigMapNames(await kubectlAsync('get configmaps -n vela-system -o name'));
+                const componentSchemas = new Map<string, JsonObject>();
+                for (const name of cmNames) {
+                    const entry = parseComponentSchema(name, await kubectlAsync(`get configmap ${name} -n vela-system -o json`));
+                    if (entry) {
+                        componentSchemas.set(...entry);
+                    }
+                }
+                const composed = stripDefaultsFromRequired(composeSchema(appSchema, componentSchemas)) as JsonObject;
+                composed.title = `KubeVela Application | Cluster: ${getK8sContext()}`;
+                this.schemaContent = JSON.stringify(composed);
+                this.writeCache(this.schemaContent);
+            } catch (err) {
+                console.error('Failed to refresh schemas from cluster:', err);
+            } finally {
+                this.refreshing = false;
+            }
+        })();
+    }
+
+    private requestSchema(resource: string): string | undefined {
+        const uri = vscode.Uri.parse(resource);
+        if (uri.scheme !== 'file') {
+            return undefined;
+        }
+
+        const doc = vscode.workspace.textDocuments.find(d => d.uri.toString() === resource);
+        const content = doc
+            ? doc.getText()
+            : fs.readFileSync(uri.fsPath, 'utf-8');
+
+        if (isVelaApplication(content)) {
+            return buildSchemaUri(getK8sContext());
+        }
+
+        return undefined;
+    }
+
+    private requestSchemaContent(uri: string): string | undefined {
+        if (!uri.startsWith(`${SCHEMA_ID}://`)) {
+            return undefined;
+        }
+
+        if (!this.schemaContent) {
+            try {
+                this.fetchSchemaFromClusterSync();
+            } catch (err) {
+                console.error('Failed to fetch schemas from cluster:', err);
+                return undefined;
+            }
+        } else {
+            this.refreshInBackground();
+        }
+
+        return this.schemaContent;
+    }
+}

--- a/validation/src/VelaYamlSchemaProvider.ts
+++ b/validation/src/VelaYamlSchemaProvider.ts
@@ -97,15 +97,15 @@ function parseComponentSchema(name: string, cmJson: string): [string, JsonObject
     return undefined;
 }
 
-function stripDefaultsFromRequired(schema: unknown): unknown {
+function makeDefaultedFieldsOptional(schema: unknown): unknown {
     if (Array.isArray(schema)) {
-        return schema.map(item => stripDefaultsFromRequired(item));
+        return schema.map(item => makeDefaultedFieldsOptional(item));
     }
     if (schema !== null && typeof schema === 'object') {
         const obj = schema as JsonObject;
         const result: JsonObject = {};
         for (const [key, value] of Object.entries(obj)) {
-            result[key] = stripDefaultsFromRequired(value);
+            result[key] = makeDefaultedFieldsOptional(value);
         }
         const required = result['required'];
         const properties = result['properties'];
@@ -215,7 +215,7 @@ export class VelaYamlSchemaProvider {
                 componentSchemas.set(...entry);
             }
         }
-        const composed = stripDefaultsFromRequired(composeSchema(appSchema, componentSchemas)) as JsonObject;
+        const composed = makeDefaultedFieldsOptional(composeSchema(appSchema, componentSchemas)) as JsonObject;
         composed.title = `KubeVela Application | Cluster: ${getK8sContext()}`;
         this.schemaContent = JSON.stringify(composed);
         this.writeCache(this.schemaContent);
@@ -238,7 +238,7 @@ export class VelaYamlSchemaProvider {
                         componentSchemas.set(...entry);
                     }
                 }
-                const composed = stripDefaultsFromRequired(composeSchema(appSchema, componentSchemas)) as JsonObject;
+                const composed = makeDefaultedFieldsOptional(composeSchema(appSchema, componentSchemas)) as JsonObject;
                 composed.title = `KubeVela Application | Cluster: ${getK8sContext()}`;
                 this.schemaContent = JSON.stringify(composed);
                 this.writeCache(this.schemaContent);

--- a/validation/src/VelaYamlSchemaProvider.ts
+++ b/validation/src/VelaYamlSchemaProvider.ts
@@ -89,6 +89,18 @@ function filterConfigMapNames(nameListOutput: string, prefix: string): string[] 
         .filter(n => !/-v\d+$/.test(n));
 }
 
+function parseDefinitionDescriptions(definitionsJson: string): Map<string, string> {
+    const descriptions = new Map<string, string>();
+    const items = JSON.parse(definitionsJson).items as Array<{ metadata: { name: string; annotations?: Record<string, string> } }>;
+    for (const item of items) {
+        const desc = item.metadata.annotations?.['definition.oam.dev/description'];
+        if (desc) {
+            descriptions.set(item.metadata.name, desc);
+        }
+    }
+    return descriptions;
+}
+
 function parseConfigMapSchema(name: string, prefix: string, cmJson: string): [string, JsonObject] | undefined {
     const cm = JSON.parse(cmJson);
     const type = name.replace(prefix, '');
@@ -128,17 +140,23 @@ function makeDefaultedFieldsOptional(schema: unknown): unknown {
     return schema;
 }
 
-interface SchemasByKind {
-    components: Map<string, JsonObject>;
-    traits: Map<string, JsonObject>;
-    policies: Map<string, JsonObject>;
+interface DefinitionSchemas {
+    schemas: Map<string, JsonObject>;
+    descriptions: Map<string, string>;
 }
 
-function injectAllOf(itemsNode: JsonObject | undefined, schemas: Map<string, JsonObject>): void {
+interface SchemasByKind {
+    components: DefinitionSchemas;
+    traits: DefinitionSchemas;
+    policies: DefinitionSchemas;
+}
+
+function injectAllOf(itemsNode: JsonObject | undefined, { schemas, descriptions }: DefinitionSchemas): void {
     if (!itemsNode || schemas.size === 0) {
         return;
     }
     const allOf: JsonObject[] = [];
+    const typeOneOf: JsonObject[] = [];
     for (const [type, schema] of schemas) {
         allOf.push({
             if: {
@@ -149,8 +167,18 @@ function injectAllOf(itemsNode: JsonObject | undefined, schemas: Map<string, Jso
                 properties: { properties: schema },
             },
         });
+        const entry: JsonObject = { const: type };
+        const desc = descriptions.get(type);
+        if (desc) {
+            entry.description = desc;
+        }
+        typeOneOf.push(entry);
     }
     itemsNode.allOf = allOf;
+    const props = (itemsNode as any).properties;
+    if (props?.type) {
+        props.type = { ...props.type, oneOf: typeOneOf };
+    }
 }
 
 function composeSchema(appSchema: JsonObject, schemas: SchemasByKind): JsonObject {
@@ -161,9 +189,9 @@ function composeSchema(appSchema: JsonObject, schemas: SchemasByKind): JsonObjec
     injectAllOf(componentItems?.properties?.traits?.items, schemas.traits);
     injectAllOf(spec?.properties?.policies?.items, schemas.policies);
 
-    console.log('composeSchema: components allOf count:', schemas.components.size);
-    console.log('composeSchema: traits allOf count:', schemas.traits.size);
-    console.log('composeSchema: policies allOf count:', schemas.policies.size);
+    console.log('composeSchema: components allOf count:', schemas.components.schemas.size);
+    console.log('composeSchema: traits allOf count:', schemas.traits.schemas.size);
+    console.log('composeSchema: policies allOf count:', schemas.policies.schemas.size);
     console.log('composeSchema: traits items node exists:', !!componentItems?.properties?.traits?.items);
     console.log('composeSchema: policies items node exists:', !!spec?.properties?.policies?.items);
 
@@ -248,10 +276,13 @@ export class VelaYamlSchemaProvider {
     private fetchSchemaFromClusterSync(): void {
         const appSchema = parseApplicationSchema(kubectlSync('get crd applications.core.oam.dev -o json'));
         const cmNameList = kubectlSync('get configmaps -n vela-system -o name');
+        const componentDescs = parseDefinitionDescriptions(kubectlSync('get componentdefinitions.core.oam.dev -n vela-system -o json'));
+        const traitDescs = parseDefinitionDescriptions(kubectlSync('get traitdefinitions.core.oam.dev -n vela-system -o json'));
+        const policyDescs = parseDefinitionDescriptions(kubectlSync('get policydefinitions.core.oam.dev -n vela-system -o json'));
         const schemas: SchemasByKind = {
-            components: this.fetchConfigMapSchemasSync(cmNameList, 'component-schema-'),
-            traits: this.fetchConfigMapSchemasSync(cmNameList, 'trait-schema-'),
-            policies: this.fetchConfigMapSchemasSync(cmNameList, 'policy-schema-'),
+            components: { schemas: this.fetchConfigMapSchemasSync(cmNameList, 'component-schema-'), descriptions: componentDescs },
+            traits: { schemas: this.fetchConfigMapSchemasSync(cmNameList, 'trait-schema-'), descriptions: traitDescs },
+            policies: { schemas: this.fetchConfigMapSchemasSync(cmNameList, 'policy-schema-'), descriptions: policyDescs },
         };
         const composed = makeDefaultedFieldsOptional(composeSchema(appSchema, schemas)) as JsonObject;
         composed.title = `KubeVela Application | Cluster: ${getK8sContext()}`;
@@ -269,10 +300,13 @@ export class VelaYamlSchemaProvider {
             try {
                 const appSchema = parseApplicationSchema(await kubectlAsync('get crd applications.core.oam.dev -o json'));
                 const cmNameList = await kubectlAsync('get configmaps -n vela-system -o name');
+                const componentDescs = parseDefinitionDescriptions(await kubectlAsync('get componentdefinitions.core.oam.dev -n vela-system -o json'));
+                const traitDescs = parseDefinitionDescriptions(await kubectlAsync('get traitdefinitions.core.oam.dev -n vela-system -o json'));
+                const policyDescs = parseDefinitionDescriptions(await kubectlAsync('get policydefinitions.core.oam.dev -n vela-system -o json'));
                 const schemas: SchemasByKind = {
-                    components: await this.fetchConfigMapSchemasAsync(cmNameList, 'component-schema-'),
-                    traits: await this.fetchConfigMapSchemasAsync(cmNameList, 'trait-schema-'),
-                    policies: await this.fetchConfigMapSchemasAsync(cmNameList, 'policy-schema-'),
+                    components: { schemas: await this.fetchConfigMapSchemasAsync(cmNameList, 'component-schema-'), descriptions: componentDescs },
+                    traits: { schemas: await this.fetchConfigMapSchemasAsync(cmNameList, 'trait-schema-'), descriptions: traitDescs },
+                    policies: { schemas: await this.fetchConfigMapSchemasAsync(cmNameList, 'policy-schema-'), descriptions: policyDescs },
                 };
                 const composed = makeDefaultedFieldsOptional(composeSchema(appSchema, schemas)) as JsonObject;
                 composed.title = `KubeVela Application | Cluster: ${getK8sContext()}`;

--- a/validation/src/extension.ts
+++ b/validation/src/extension.ts
@@ -4,6 +4,7 @@ import * as vscode from 'vscode';
 import { DiagnosticProvider } from './DiagnosticsProvider';
 import { CueVetDiagnosticsProvider } from './CueVetDiagnosticsProvider';
 import { VelaVetDiagnosticsProvider } from './VelaVetDiagnosticsProvider';
+import { VelaYamlSchemaProvider } from './VelaYamlSchemaProvider';
 
 let disposables: Disposable[] = [];
 
@@ -39,7 +40,10 @@ const diagnosticProviders: DiagnosticProvider[] = [
   new CueVetDiagnosticsProvider(languages.createDiagnosticCollection('cue vet'))
 ];
 
-export function activate(context: ExtensionContext) {
+export async function activate(context: ExtensionContext) {
+  const yamlSchemaProvider = new VelaYamlSchemaProvider(context.globalStorageUri.fsPath);
+  await yamlSchemaProvider.register();
+
   for (const provider of diagnosticProviders) {
     provider.activate();
   }


### PR DESCRIPTION

![CleanShot 2026-03-04 at 21 36 53](https://github.com/user-attachments/assets/94ffac09-3169-45eb-9ff6-ad94bbaae14a)


## Summary

- Integrates with Red Hat YAML extension (`redhat.vscode-yaml`) to dynamically serve JSON schemas for OAM Application files (`apiVersion: core.oam.dev/v1beta1`, `kind: Application`)
- Fetches Application schema, ObjectMeta, component/trait/policy schemas, and type descriptions from the live K8s cluster
- Composes conditional `allOf`/`if`/`then` validation per component, trait, and policy type
- Persistent schema cache with stale-while-revalidate pattern across VSCode sessions
- Strips runtime-only fields (`status`, ObjectMeta runtime fields) and makes defaulted fields optional

## Test plan

- [x] Open a YAML file with `apiVersion: core.oam.dev/v1beta1` and `kind: Application` — schema should activate
- [x] Verify autocomplete for component, trait, and policy types with descriptions
- [x] Verify autocomplete for `metadata` fields (name, namespace, labels, annotations)
- [x] Verify fields with defaults are not flagged as required
- [x] Clear cache, reopen file — schema should be fetched from cluster synchronously
- [x] Reopen file after background refresh — updated schema should be served

🤖 Generated with [Claude Code](https://claude.com/claude-code)