### PR TITLE
feat: add tool path configuration and installation prompts

### DIFF
--- a/validation/package.json
+++ b/validation/package.json
@@ -9,9 +9,6 @@
   "engines": {
     "vscode": "^1.73.0"
   },
-  "categories": [
-    "Other"
-  ],
   "activationEvents": [
     "onLanguage:yaml",
     "onLanguage:manifest-yaml"
@@ -26,6 +23,24 @@
           "default": true,
           "description": "Exclude +ignore fields.",
           "order": 0
+        },
+        "velaValidation.tools.kubectlPath": {
+          "type": "string",
+          "default": "",
+          "description": "Path to the kubectl binary. Leave empty to use the one on your PATH.",
+          "order": 1
+        },
+        "velaValidation.tools.cuePath": {
+          "type": "string",
+          "default": "",
+          "description": "Path to the cue binary. Leave empty to use the one on your PATH.",
+          "order": 2
+        },
+        "velaValidation.tools.velaPath": {
+          "type": "string",
+          "default": "",
+          "description": "Path to the vela binary. Leave empty to use the one on your PATH.",
+          "order": 3
         }
       }
     }

--- a/validation/package.json
+++ b/validation/package.json
@@ -11,7 +11,8 @@
   },
   "activationEvents": [
     "onLanguage:yaml",
-    "onLanguage:manifest-yaml"
+    "onLanguage:manifest-yaml",
+    "onLanguage:cue"
   ],
   "main": "./out/extension",
   "contributes": {

--- a/validation/src/CueVetDiagnosticsProvider.ts
+++ b/validation/src/CueVetDiagnosticsProvider.ts
@@ -1,6 +1,7 @@
 import * as vscode from 'vscode';
 import { DiagnosticProvider } from './DiagnosticsProvider';
 import { spawn } from 'child_process';
+import { getToolPath } from './ToolManager';
 import { writeFileSync, rmSync, mkdtempSync } from 'fs';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
@@ -77,7 +78,7 @@ export class CueVetDiagnosticsProvider implements DiagnosticProvider {
 
         writeFileSync(`${this.tempDirectory}/${fileName}`, tempFileContent);
 
-        const command = `cue vet ${this.tempDirectory}/${fileName}`;
+        const command = `${getToolPath('cue')} vet ${this.tempDirectory}/${fileName}`;
 
         const process = spawn(command, { shell: true });
 

--- a/validation/src/ToolManager.ts
+++ b/validation/src/ToolManager.ts
@@ -1,0 +1,90 @@
+import * as vscode from 'vscode';
+import { execSync } from 'child_process';
+
+interface ToolDefinition {
+    name: string;
+    settingKey: string;
+    installUrl: string;
+}
+
+const TOOLS: ToolDefinition[] = [
+    {
+        name: 'kubectl',
+        settingKey: 'velaValidation.tools.kubectlPath',
+        installUrl: 'https://kubernetes.io/docs/tasks/tools/',
+    },
+    {
+        name: 'cue',
+        settingKey: 'velaValidation.tools.cuePath',
+        installUrl: 'https://cuelang.org/docs/install/',
+    },
+    {
+        name: 'vela',
+        settingKey: 'velaValidation.tools.velaPath',
+        installUrl: 'https://kubevela.io/docs/installation/kubernetes#install-vela-cli',
+    },
+];
+
+function whichSync(name: string): string | undefined {
+    try {
+        return execSync(`which ${name}`, { encoding: 'utf-8', timeout: 5_000 }).trim() || undefined;
+    } catch {
+        return undefined;
+    }
+}
+
+function isExecutable(toolPath: string): boolean {
+    try {
+        execSync(`"${toolPath}" version`, { encoding: 'utf-8', timeout: 5_000, stdio: 'ignore' });
+        return true;
+    } catch {
+        try {
+            execSync(`"${toolPath}" --version`, { encoding: 'utf-8', timeout: 5_000, stdio: 'ignore' });
+            return true;
+        } catch {
+            return false;
+        }
+    }
+}
+
+export function getToolPath(name: 'kubectl' | 'cue' | 'vela'): string {
+    const tool = TOOLS.find(t => t.name === name)!;
+    const configured = vscode.workspace.getConfiguration().get<string>(tool.settingKey);
+    if (configured) {
+        return configured;
+    }
+    return name;
+}
+
+export async function checkTools(): Promise<void> {
+    for (const tool of TOOLS) {
+        const configured = vscode.workspace.getConfiguration().get<string>(tool.settingKey);
+
+        if (configured) {
+            if (!isExecutable(configured)) {
+                const action = await vscode.window.showWarningMessage(
+                    `Configured path for "${tool.name}" is not valid: ${configured}`,
+                    'Open Settings'
+                );
+                if (action === 'Open Settings') {
+                    vscode.commands.executeCommand('workbench.action.openSettings', tool.settingKey);
+                }
+            }
+            continue;
+        }
+
+        const found = whichSync(tool.name);
+        if (!found) {
+            const action = await vscode.window.showWarningMessage(
+                `"${tool.name}" was not found on your PATH. Some features will be unavailable.`,
+                'Install',
+                'Configure Path'
+            );
+            if (action === 'Install') {
+                vscode.env.openExternal(vscode.Uri.parse(tool.installUrl));
+            } else if (action === 'Configure Path') {
+                vscode.commands.executeCommand('workbench.action.openSettings', tool.settingKey);
+            }
+        }
+    }
+}

--- a/validation/src/VelaVetDiagnosticsProvider.ts
+++ b/validation/src/VelaVetDiagnosticsProvider.ts
@@ -1,6 +1,7 @@
 import * as vscode from 'vscode';
 import { DiagnosticProvider } from './DiagnosticsProvider';
 import { spawn } from 'child_process';
+import { getToolPath } from './ToolManager';
 
 export class VelaVetDiagnosticsProvider implements DiagnosticProvider {
     private collection: vscode.DiagnosticCollection
@@ -30,7 +31,7 @@ export class VelaVetDiagnosticsProvider implements DiagnosticProvider {
     }
 
     runCommand(document: vscode.TextDocument): Promise<string> {
-        const command = `vela def vet ${document.fileName}`;
+        const command = `${getToolPath('vela')} def vet ${document.fileName}`;
 
         const process = spawn(command, { shell: true });
 

--- a/validation/src/VelaYamlSchemaProvider.ts
+++ b/validation/src/VelaYamlSchemaProvider.ts
@@ -3,6 +3,7 @@ import * as path from 'path';
 import * as fs from 'fs';
 import { exec, execSync } from 'child_process';
 import { promisify } from 'util';
+import { getToolPath } from './ToolManager';
 
 const execAsync = promisify(exec);
 
@@ -11,7 +12,7 @@ const CACHE_FILENAME = 'vela-application-schema.json';
 
 function getK8sContext(): string {
     try {
-        return execSync('kubectl config current-context', { encoding: 'utf-8', timeout: 5_000 }).trim();
+        return execSync(`${getToolPath('kubectl')} config current-context`, { encoding: 'utf-8', timeout: 5_000 }).trim();
     } catch {
         return 'unknown';
     }
@@ -64,11 +65,11 @@ function isVelaApplication(content: string): boolean {
 const KUBECTL_OPTS = { timeout: 10_000, maxBuffer: 10 * 1024 * 1024 };
 
 function kubectlSync(args: string): string {
-    return execSync(`kubectl ${args}`, { encoding: 'utf-8', ...KUBECTL_OPTS });
+    return execSync(`${getToolPath('kubectl')} ${args}`, { encoding: 'utf-8', ...KUBECTL_OPTS });
 }
 
 async function kubectlAsync(args: string): Promise<string> {
-    const { stdout } = await execAsync(`kubectl ${args}`, KUBECTL_OPTS);
+    const { stdout } = await execAsync(`${getToolPath('kubectl')} ${args}`, KUBECTL_OPTS);
     return stdout;
 }
 

--- a/validation/src/extension.ts
+++ b/validation/src/extension.ts
@@ -5,6 +5,7 @@ import { DiagnosticProvider } from './DiagnosticsProvider';
 import { CueVetDiagnosticsProvider } from './CueVetDiagnosticsProvider';
 import { VelaVetDiagnosticsProvider } from './VelaVetDiagnosticsProvider';
 import { VelaYamlSchemaProvider } from './VelaYamlSchemaProvider';
+import { checkTools } from './ToolManager';
 
 let disposables: Disposable[] = [];
 
@@ -41,6 +42,8 @@ const diagnosticProviders: DiagnosticProvider[] = [
 ];
 
 export async function activate(context: ExtensionContext) {
+  checkTools();
+
   const yamlSchemaProvider = new VelaYamlSchemaProvider(context.globalStorageUri.fsPath);
   await yamlSchemaProvider.register();
 


### PR DESCRIPTION

<img width="952" height="296" alt="CleanShot 2026-04-01 at 12 16 36@2x" src="https://github.com/user-attachments/assets/4ab82eb3-ca59-4066-a6a1-39edb07f97ff" />


## Summary
- Added configurable tool paths for kubectl, cue, and vela binaries
- Implemented automatic tool detection with installation prompts when tools are missing
- Created ToolManager to centralize tool path resolution and validation
- Added cue language activation event to support CueLang file validation

## Test plan
- [x] Open a workspace with the extension installed
- [x] Verify tool detection prompts appear for missing tools
- [x] Configure custom tool paths in settings and verify they are used
- [x] Test YAML validation with Vela applications
- [x] Test CueLang file validation
- [x] Verify kubectl, cue, and vela commands resolve correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)